### PR TITLE
Return success! by default if service composition flattens to nil

### DIFF
--- a/lib/workflows/service.rb
+++ b/lib/workflows/service.rb
@@ -36,7 +36,7 @@ module Workflows
     # This is a dead giveaway that functions of this type signature will have side effects.
     #
     def compose_with_error_handling(*fns)
-      fns.flatten.compact.inject do |composed, fn|
+      fn = fns.flatten.compact.inject do |composed, fn|
         -> {
           last_return = composed.call
           if Workflows::Error.error?(last_return)
@@ -46,6 +46,7 @@ module Workflows
           end
         }
       end
+      fn || -> { success! }
     end
   end
 end

--- a/spec/workflows/service_spec.rb
+++ b/spec/workflows/service_spec.rb
@@ -43,6 +43,12 @@ describe Workflows::Service do
       expect(r).to be_instance_of(Workflows::ErrorValue)
       expect(r.value).to eq("error")
     end
+
+    it 'returns a success lambda if composition flattens to nil' do
+      r = subject.compose_with_error_handling([[], [nil], nil])
+      expect(subject).to receive(:success!).and_call_original
+      expect(r.call).to eq(true)
+    end
   end
 
   describe '.call_each' do


### PR DESCRIPTION
Seems that sometimes nested services end up flattening/compacting to `nil`; in this case all the work that was done (none) is completed, so should return `success!`.
